### PR TITLE
Fix - close mongo connection after import

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -4,17 +4,17 @@
     <property file="build.properties"/>
 
     <target name="clean">
-        <delete dir="${build.dir}"/>
+        <delete dir="build"/>
     </target>
 
     <target name="init" depends="clean">
-        <mkdir dir="${build.dir}"/>
-        <ivy:retrieve />
+        <mkdir dir="build"/>
+<!--        <ivy:retrieve /> -->
     </target>
 
     <path id="build.classpath">
-        <fileset dir="${basedir}/">
-            <include name="${lib.dir}/*.jar"/>
+        <fileset dir=".">
+            <include name="lib/*.jar"/>
         </fileset>
     </path>
 
@@ -30,18 +30,18 @@
 
 
     <path id="jars">
-        <fileset dir="${lib.dir}" includes="**/*.jar"/>
+        <fileset dir="lib" includes="**/*.jar"/>
     </path>
 
     <target name="compile" depends="init">
 
-        <mkdir dir="${build.dir}"/>
-        <javac srcdir="${src.dir}" destdir="${build.dir}" classpathref="jars" debug="on"/>
+        <mkdir dir="build"/>
+        <javac srcdir="src" destdir="build" classpathref="jars" debug="on"/>
     </target>
 
 
     <target name="jar" depends="compile">
-        <jar basedir="${build.dir}" destfile="${store.dir}/solr-mongo-importer.jar" />
+        <jar basedir="build" destfile="dest/solr-mongo-importer.jar" />
     </target>
 
 </project>

--- a/ivy.xml
+++ b/ivy.xml
@@ -8,7 +8,7 @@
         <conf name="default" transitive="true" visibility="public" extends="master" />
     </configurations>
     <dependencies>
-        <dependency org="org.mongodb" name="mongo-java-driver" rev="2.8.0"
+        <dependency org="org.mongodb" name="mongo-java-driver" rev="2.11.1"
                     conf="compile->compile(*),master(*);runtime->runtime(*);master->master(*)"/>
         <dependency org="org.apache.solr" name="solr-dataimporthandler" rev="3.6.0"
                     conf="compile->compile(*),master(*);runtime->runtime(*);master->master(*)"/>

--- a/src/main/org/apache/solr/handler/dataimport/MongoDataSource.java
+++ b/src/main/org/apache/solr/handler/dataimport/MongoDataSource.java
@@ -47,6 +47,8 @@ public class MongoDataSource extends DataSource<Iterator<Map<String, Object>>>{
 
         try {
             Mongo mongo  = new Mongo( host, Integer.parseInt( port ) );
+            mongo.setReadPreference(ReadPreference.secondaryPreferred());
+
             this.mongoDb = mongo.getDB( databaseName );
 
             if( username != null ){

--- a/src/main/org/apache/solr/handler/dataimport/MongoDataSource.java
+++ b/src/main/org/apache/solr/handler/dataimport/MongoDataSource.java
@@ -29,6 +29,7 @@ public class MongoDataSource extends DataSource<Iterator<Map<String, Object>>>{
 
     private DBCollection mongoCollection;
     private DB           mongoDb;
+    private Mongo        mongoConnection;
 
     private DBCursor mongoCursor;
     
@@ -49,6 +50,7 @@ public class MongoDataSource extends DataSource<Iterator<Map<String, Object>>>{
             Mongo mongo  = new Mongo( host, Integer.parseInt( port ) );
             mongo.setReadPreference(ReadPreference.secondaryPreferred());
 
+            this.mongoConnection = mongo;
             this.mongoDb = mongo.getDB( databaseName );
 
             if( username != null ){
@@ -169,6 +171,10 @@ public class MongoDataSource extends DataSource<Iterator<Map<String, Object>>>{
         if( this.mongoCursor != null ){
             this.mongoCursor.close();
         }
+
+        if (this.mongoConnection !=null ){
+            this.mongoConnection.close();
+        }
     }
 
 
@@ -179,3 +185,4 @@ public class MongoDataSource extends DataSource<Iterator<Map<String, Object>>>{
     public static final String PASSWORD   = "password";
 
 }
+


### PR DESCRIPTION
Howdy,

We ran into an issue where our mongo started refusing connections from solr because there were too many open concurrent connections. This is because the module never closes the mongo connection after completing an import.

We also need to make changes to it to support Mongo replica sets and had to upgrade the mongo driver version to do so, but the closing of the mongo connection after import is the important patch.

cheers,
Boris.